### PR TITLE
Fix pango.modules generation

### DIFF
--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -103,6 +103,7 @@ class Bundler:
                 line = "@executable_path/../Resources" + line
 
             fout.write(line)
+            fout.write("\n")
         fout.close()
 
         os.unlink(tmp_filename)


### PR DESCRIPTION
pango.modules doesn't have newlines inserted, this commit fixes it.
