### PR TITLE
Use CFBundleName instead of CFBundleExecutable for bundle name

### DIFF
--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -27,7 +27,7 @@ class Bundler:
         # Create the bundle in a temporary location first and move it
         # to the final destination when done.
         self.meta = project.get_meta()
-        self.bundle_path = os.path.join(self.meta.dest, "." + project.get_name() + ".app")
+        self.bundle_path = os.path.join(self.meta.dest, "." + project.get_bundle_name() + ".app")
 
     def recursive_rm(self, dirname):
         # Extra safety ;)
@@ -541,7 +541,7 @@ class Bundler:
         path = self.project.evaluate_path(self.bundle_path)
         self.recursive_rm(path)
 
-        final_path = os.path.join(self.meta.dest, self.project.get_name() + ".app")
+        final_path = os.path.join(self.meta.dest, self.project.get_bundle_name() + ".app")
         final_path = self.project.evaluate_path(final_path)
 
         if not self.meta.overwrite and os.path.exists(final_path):

--- a/bundler/project.py
+++ b/bundler/project.py
@@ -239,6 +239,10 @@ class Project:
             else:
                 raise
         self.name = plist.CFBundleExecutable
+        if plist.has_key("CFBundleName"):
+            self.bundle_name = plist.CFBundleName
+        else:
+            self.bundle_name = plist.CFBundleExecutable
  
     """
      Replace ${env:?}, ${prefix}, ${prefix:?}, ${project}, ${gtk}, ${gtkdir},
@@ -285,6 +289,9 @@ class Project:
 
     def get_name(self):
         return self.name
+
+    def get_bundle_name(self):
+        return self.bundle_name
 
     def get_prefix(self, name="default"):
         meta = self.get_meta()


### PR DESCRIPTION
If available, use CFBundleName instead of CFBundleExecutable for the bundle name.

I've used this approach myself to package inkscape.
It needs an executable in Contents/MacOS/inkscape in lowercase, whereas the rest of the interface should use a capitalized Inkscape.
