### PR TITLE
launcher: Update for pango changes

### DIFF
--- a/bundler/launcher.sh
+++ b/bundler/launcher.sh
@@ -33,7 +33,8 @@ export GTK_PATH="$bundle_res"
 export GTK2_RC_FILES="$bundle_etc/gtk-2.0/gtkrc"
 export GTK_IM_MODULE_FILE="$bundle_etc/gtk-2.0/gtk.immodules"
 export GDK_PIXBUF_MODULE_FILE="$bundle_etc/gtk-2.0/gdk-pixbuf.loaders"
-export PANGO_RC_FILE="$bundle_etc/pango/pangorc"
+export PANGO_LIBDIR="$bundle_lib"
+export PANGO_SYSCONFDIR="$bundle_etc"
 
 # Localization settings. It's better to do this inside your program
 # using NSLocale if possible.


### PR DESCRIPTION
The newish changes to pango require a slightly different default launcher.sh. See:

https://mail.gnome.org/archives/gtk-osx-users-list/2012-December/msg00009.html
https://mail.gnome.org/archives/gtk-osx-users-list/2013-January/msg00053.html
