### PR TITLE
Make sure that libraries are writeable before using otool

### DIFF
--- a/bundler/run-install-name-tool-change.sh
+++ b/bundler/run-install-name-tool-change.sh
@@ -10,6 +10,8 @@ WRONG_PREFIX=$2
 RIGHT_PREFIX="@executable_path/../$3"
 ACTION=$4
 
+chmod u+w $LIBRARY
+
 if [ "x$ACTION" == "xchange" ]; then
     libs="`otool -L $LIBRARY 2>/dev/null | fgrep compatibility | cut -d\( -f1 | grep $WRONG_PREFIX | sort | uniq`"
     for lib in $libs; do


### PR DESCRIPTION
This change would help with using gtk-mac-bundler with macports. At least libssl and libcrypto are not writeable.
