### PR TITLE
Make pango modules related code optional to fix build with pango 1.38

### DIFF
--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -68,6 +68,12 @@ class Bundler:
         self.copy_path(path)
 
     def create_pango_setup(self):
+        if utils.has_pkgconfig_module("pango") and \
+                not utils.has_pkgconfig_variable("pango", "pango_module_version"):
+            # Newer pango (>= 1.38) no longer has modules, skip this
+            # step in that case.
+            return
+
         # Create a temporary pangorc file just for creating the
         # modules file with the right modules.
         module_version = utils.evaluate_pkgconfig_variables("${pkg:pango:pango_module_version}")

--- a/examples/gtk-demo.bundle
+++ b/examples/gtk-demo.bundle
@@ -79,9 +79,11 @@
     ${prefix}/lib/gdk-pixbuf-2.0/${pkg:${gtk}:gtk_binary_version}/loaders/*.so
   </binary>
 
+<!-- No longer needed for pango >= 1.38
    <binary>
     ${prefix}/lib/pango/${pkg:pango:pango_module_version}/modules/
   </binary>
+-->
 
   <data>
     ${prefix}/etc/pango/

--- a/examples/gtk3-demo.bundle
+++ b/examples/gtk3-demo.bundle
@@ -69,9 +69,11 @@
     ${prefix}/lib/gdk-pixbuf-2.0/${pkg:gdk-pixbuf-2.0:gdk_pixbuf_binary_version}/loaders/*.so
   </binary>
 
+<!-- No longer needed for pango >= 1.38
   <binary>
     ${prefix}/lib/pango/${pkg:pango:pango_module_version}/modules/
   </binary>
+-->
 
   <!-- Translation filenames, one for each program or library that you
        want to copy in to the bundle. The "dest" attribute is

--- a/examples/gtk3-launcher.sh
+++ b/examples/gtk3-launcher.sh
@@ -29,9 +29,11 @@ export GTK_DATA_PREFIX="$bundle_res"
 export GTK_EXE_PREFIX="$bundle_res"
 export GTK_PATH="$bundle_res"
 
+# PANGO_* is no longer needed for pango >= 1.38
 export PANGO_RC_FILE="$bundle_etc/pango/pangorc"
 export PANGO_SYSCONFDIR="$bundle_etc"
 export PANGO_LIBDIR="$bundle_lib"
+
 export GDK_PIXBUF_MODULE_FILE="$bundle_lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 if [ `uname -r | cut -d . -f 1` -ge 10 ]; then
     export GTK_IM_MODULE_FILE="$bundle_etc/gtk-3.0/gtk.immodules"


### PR DESCRIPTION
pango 1.38 no longer builds separate modules and has removed the
"pango_module_version" pkg-config var. This makes the pango
bundle code optional depending on the presence of the modules and
adds an error message to help users update their bundle xml file
in case a newer pango is present.