### PR TITLE
Attempt to fix otool/gimp issue with a subdirs

### DIFF
--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -347,7 +347,8 @@ class Bundler(object):
                         dir, pattern = os.path.split(source)
                         for root, dirs, files in os.walk(dir):
                             for item in glob.glob(os.path.join(root, pattern)):
-                                binaries.append(os.path.join(root, item))
+                                if os.path.isfile(os.path.join(root, item)):
+                                    binaries.append(os.path.join(root, item))
                     elif os.path.isdir(source):
                         for root, dirs, files in os.walk(source):
                             for item in glob.glob(os.path.join(root, '*.so')):


### PR DESCRIPTION
Hello,

I found an issue with GIMP packaging.

To add GIMP plugins and all it dependencies i added such line to my bundle file:
```xml
 <binary>${prefix}/lib/gimp/2.0/plug-ins/*</binary>
```
However, i found that otool is failing because it is called with not only files but also directories (GIMP has some plugins in subdirs). Also i found that depending on SDK version otool crashing, printing warnings or just exiting with a fatal message (last SDK). This PR filtering list to files-only