### PR TITLE
replace deprecated plistlib.readPlist() with load() for py-3.9 compatibility

### DIFF
--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -18,7 +18,7 @@ class Bundler(object):
         self.project_dir = project.get_project_dir()
 
         plist_path = self.project.get_plist_path()
-        self.plist = plistlib.readPlist(plist_path)
+        self.plist = plistlib.load(open(plist_path, "rb"))
 
         # List of paths that should be recursively searched for
         # binaries that are used to find library dependencies.

--- a/bundler/project.py
+++ b/bundler/project.py
@@ -510,7 +510,7 @@ class Project(object):
 
         plist_path = self.get_plist_path()
         try:
-            plist = plistlib.readPlist(plist_path)
+            plist = plistlib.load(open(plist_path, "rb"))
         except EnvironmentError as e:
             if e.errno == errno.ENOENT:
                 print("Info.plist file not found: " + plist_path)


### PR DESCRIPTION
plistlib.readPlist() has been [deprecated](https://docs.python.org/3/library/plistlib.html#module-plistlib): "Deprecated since version 3.4: Use load() instead."
Since Python 3.9 it has been removed for good. This small change fixes it and makes it run again on Python >=3.9