### PR TITLE
make Python3.9 compatible - adapt env and plistlib.load()

### DIFF
--- a/bundler/bundler.py
+++ b/bundler/bundler.py
@@ -18,7 +18,8 @@ class Bundler(object):
         self.project_dir = project.get_project_dir()
 
         plist_path = self.project.get_plist_path()
-        self.plist = plistlib.readPlist(plist_path)
+        with open(plist_path, "rb") as f:
+            self.plist = plistlib.load(f)
 
         # List of paths that should be recursively searched for
         # binaries that are used to find library dependencies.

--- a/bundler/project.py
+++ b/bundler/project.py
@@ -510,7 +510,8 @@ class Project(object):
 
         plist_path = self.get_plist_path()
         try:
-            plist = plistlib.readPlist(plist_path)
+            with open(plist_path, "rb") as f:
+                plist = plistlib.load(f)
         except EnvironmentError as e:
             if e.errno == errno.ENOENT:
                 print("Info.plist file not found: " + plist_path)

--- a/gtk-mac-bundler.in
+++ b/gtk-mac-bundler.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 sys.path.insert(0, '@PATH@')
 


### PR DESCRIPTION
plistlib.readPlist() has been [deprecated](https://docs.python.org/3.8/library/plistlib.html#plistlib.readPlist): "Deprecated since version 3.4: Use load() instead."
Since Python 3.9 it has been removed for good. This small change fixes it and makes it run again on Python >=3.9
Also, make sure that we run on python3 by adapting the shebang env. 

/P.S.: had to give it a new try, I failed squashing the commits in the original pull request. Sorry for that 