### PR TITLE
Change evaluate_path: keep trailing ending folder separator if any.

### DIFF
--- a/bundler/project.py
+++ b/bundler/project.py
@@ -552,7 +552,11 @@ class Project(object):
         path = utils.evaluate_environment_variables(path)
         path = utils.evaluate_pkgconfig_variables(path)
 
-        return os.path.normpath(path)
+        [dirname, basename] = os.path.split(path)
+        if not basename:
+            return os.path.join(os.path.normpath(dirname), basename)
+        else:
+            return os.path.normpath(path)
 
     def get_name(self):
         return self.name


### PR DESCRIPTION
Change evaluate_path: keep trailing ending folder separator if any (from John's advice).

Allow to force parent folder creation, in that case for instance:
  <data dest="${bundle}/Contents/Resources/share/docs/my_app/">
    ${project}/data_*.txt
  </data>